### PR TITLE
[PDEV-3497] feat: Initial version

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 99

--- a/README.md
+++ b/README.md
@@ -1,2 +1,162 @@
-# setuptools_scm_git_semver
-SemVer-compatible hooks for setuptools_scm.
+# `setuptools_scm_git_semver`
+
+[SemVer]-compatible hooks for [`setuptools_scm`].
+
+This package was created because `setuptools_scm` produces [PEP 440] compliant version numbers,
+which are not compatible with SemVer.
+
+## Installation
+
+Install using [pip], e.g.
+
+```sh
+pip install setuptools_scm_git_semver
+```
+
+## Usage
+
+To configure `setuptools` to generate SemVer compatible numbers through `setuptools_scm` you could
+use:
+
+```py
+# setup.py
+from setuptools import setup
+from setuptools_scm_git_semver import parse
+
+setup(
+    ...
+    use_scm_version={
+        'parse': parse,
+        'version_scheme': 'semver',
+        'local_scheme': 'semver'
+    },
+    setup_requires=['setuptools_scm', 'setuptools_scm_git_semver'],
+    ...
+)
+
+# $ python setup.py --version
+# 1.2.4-rc.0.20190927T181700Z+ddb8be7
+```
+
+To retrieve the same version programmatically you could instead use:
+
+```py
+from setuptools_scm_git_semver import get_version
+
+get_version()
+# 1.2.4-rc.0.20190927T181700Z+ddb8be7
+```
+
+## Developing
+
+There are no tests for this, so be careful. I'm not proud – I just want SemVer versions!
+
+## Releases
+
+The package should be released to PyPI. The first release will be performed manually, and CI will be
+written later.
+
+## API
+
+This package defines a [`parse`] function, as well as [`version_scheme`] and [`local_scheme`]
+implementations that together can create valid SemVer version numbers from git. See the
+[configuration documentation] for how to configure `setuptools_scm` to use these.
+
+Additionally, there is a [`get_version`] convenience function that obtains a version number using
+the configuration in this package.
+
+### Entrypoints
+
+#### `setuptools_scm.version_scheme` (`semver`)
+
+The `semver` version scheme formats clean (no commits or unstaged changes since last tag) versions
+as the last tag, verbatim. If there *are* commits or unstaged changes, the behaviour depends on the
+last tag:
+
+- If the last tag is a pre-release, then an ISO 8601 date and time will be added as an extra
+  pre-release segment. If there are no unstaged changes, the commit time of the current `HEAD` will
+  be used. If there are unstaged changes, the current time will be used (hence note that unstaged
+  changes will cause different versions to be generated every time).
+
+  **Examples**
+
+  Given a latest tag of `1.2.3-rc.1`, and no unstaged changes with a last commit time of 18:17:00
+  UTC on 27th September 2019, the version scheme result would be:
+
+  ```
+  1.2.3-rc.1.20190927T181700Z
+  ```
+
+  If there were unstaged changes, and the current time was 15:49:32 BST on 8th October 2019, the
+  version scheme result would be:
+
+  ```
+  1.2.3-rc.1.20191008T144932Z
+  ```
+
+- If the last tag is *not* a pre-release, the 'patch' number of the last tag is bumped and an ISO
+  8601 date and time is added as a pre-release segment, as above.
+
+  **Examples**
+
+  Given a latest tag of `1.2.3`, and no unstaged changes with a last commit time of 18:17:00 UTC on
+  27th September 2019, the version scheme result would be:
+
+  ```
+  1.2.4-20190927T181700Z
+  ```
+
+  If there were unstaged changes, and the current time was 15:49:32 BST on 8th October 2019, the
+  version scheme result would be:
+
+  ```
+  1.2.4-20191008T144932Z
+  ```
+
+These choices ensure that versions generated from newer commits (or at a later time, when there are
+unstaged changes) will be sorted higher than versions from older commits (or earlier times).
+
+#### `setuptools_scm.local_scheme` (`semver`)
+
+The `semver` local scheme does nothing when there are no commits since the last tag. When there are,
+it returns a build metadata segment with a short hash for the latest commit.
+
+**Example**
+
+Given there are commits since the last tag and the latest commit's hash is
+`ddb8be7ecb639fe0d5f72aeb46fe0b86eb77d00d`, the local scheme result would be:
+
+```
++ddb8be7
+```
+
+Per the spec, build metadata has no effect on ordering so this is for additional context only.
+
+### Functions
+
+#### `git.parse`
+
+Constructs a `setuptools_scm.version.ScmVersion` from a given `root` directory and `config`, parsing
+and storing the discovered git tag using [`semver.VersionInfo`].
+
+This behaves very similarly to to `setuptools_scm.git.parse` except that it also prevents
+`setuptools_scm` from parsing the tag using [`pkg_resources.parse_version`], since that results in
+[PEP 440] versions that are not SemVer-compatible.
+
+#### `get_version`
+
+A trivial wrapper around `setuptools_scm.get_version` that sets the `parse`, `version_scheme`, and
+`local_scheme` configuration to the implementations in this package. The the `setuptools_scm`
+[configuration documentation] for all options.
+
+[SemVer]: https://semver.org
+[`setuptools_scm`]: https://github.com/pypa/setuptools_scm
+[PEP 440]: https://www.python.org/dev/peps/pep-0440/#version-scheme
+[pip]: https://pip.pypa.io/en/stable/
+[`parse`]: #gitparse
+[`version_scheme`]: #setuptools_scmversion_scheme-semver
+[`local_scheme`]: #setuptools_scmlocal_scheme-semver
+[`get_version`]: #get_version
+[configuration documentation]: https://github.com/pypa/setuptools_scm/#configuration-parameters
+[`semver.VersionInfo`]: https://python-semver.readthedocs.io/en/latest/api.html#semver.VersionInfo
+[`pkg_resources.parse_version`]: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#parsing-utilities

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+from setuptools import setup
+
+setup(
+    name='setuptools_scm_git_semver',
+    use_scm_version=True,
+    author='Chris Connelly',
+    author_email='chris.connelly@cloudreach.com>',
+    description='SemVer-compatible plugin for setuptools_scm.',
+    packages=['setuptools_scm_git_semver'],
+    install_requires=['python-dateutil>=2.8,<3', 'semver>=2.8,<3', 'setuptools_scm>=3.3,<4'],
+    setup_requires=['setuptools_scm'],
+    entry_points=f"""
+        [setuptools_scm.version_scheme]
+        semver = setuptools_scm_git_semver:version_scheme_semver
+
+        [setuptools_scm.local_scheme]
+        semver = setuptools_scm_git_semver:local_scheme_semver
+    """
+)

--- a/setuptools_scm_git_semver/__init__.py
+++ b/setuptools_scm_git_semver/__init__.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+import subprocess
+
+import dateutil.parser
+import semver
+from setuptools_scm import get_version as setuptools_scm_version
+
+from .git import parse
+
+
+COMMIT_TIME_ARGS = ['git', 'show', '--pretty=%cI', '-s']
+TIME_FORMAT = '%Y%m%dT%H%M%SZ'
+
+
+def get_version(**kwargs):
+    return setuptools_scm_version(parse=parse,
+                                  version_scheme='semver',
+                                  local_scheme='semver',
+                                  **kwargs)
+
+
+def version_scheme_semver(version):
+    tag = version.tag
+
+    if not version.distance and not version.dirty:
+        return str(tag)
+
+    version.time = datetime.now() if version.dirty else _get_commit_time()
+    base = f'{tag}.' if tag.prerelease else f'{semver.bump_patch(str(tag))}-'
+    return version.format_with('{base}{time:{time_format}}', base=base, time_format=TIME_FORMAT)
+
+
+def local_scheme_semver(version):
+    if version.distance and version.node:
+        return f'+{version.node[1:]}'
+    return ''
+
+
+def _get_commit_time():
+    try:
+        commit_time = subprocess.check_output(COMMIT_TIME_ARGS, stderr=subprocess.DEVNULL).strip()
+        return dateutil.parser.isoparse(commit_time)
+    except:
+        # This could happen, e.g., if there are no commits in the repo. We assume other git issues
+        # would break before this point and assume that case for the sake of simple error handling.
+        return datetime.now()

--- a/setuptools_scm_git_semver/git.py
+++ b/setuptools_scm_git_semver/git.py
@@ -1,0 +1,52 @@
+import semver
+from setuptools_scm.git import DEFAULT_DESCRIBE, GitWorkdir, _git_parse_describe, warn_on_shallow
+from setuptools_scm.utils import has_command
+from setuptools_scm.version import meta
+
+
+def parse(root, *, config):
+    """
+    Based on https://github.com/pypa/setuptools_scm/blob/master/src/setuptools_scm/git.py#parse
+
+    This is almost a verbatim copy, except that we tell setuptools_scm that the tag is preformatted
+    to prevent them from applying Python's version normalisation.
+    """
+    if not has_command("git"):
+        return
+
+    wd = GitWorkdir.from_potential_worktree(config.absolute_root)
+    if wd is None:
+        return
+    warn_on_shallow(wd)
+
+    describe_command = config.git_describe_command or DEFAULT_DESCRIBE
+
+    out, unused_err, ret = wd.do_ex(describe_command)
+    if ret:
+        # If 'git git_describe_command' failed, try to get the information otherwise.
+        tag = '0.1.0'
+        distance = wd.count_all_nodes()
+        dirty = wd.is_dirty()
+        node = None
+        branch = None
+
+        rev_node = wd.node()
+        if rev_node is not None:
+            node = f'g{rev_node}'
+            branch = wd.get_branch()
+    else:
+        tag, distance, node, dirty = _git_parse_describe(out)
+        branch = wd.get_branch()
+
+    version = meta(
+        semver.parse_version_info(tag),
+        distance=distance,
+        dirty=dirty,
+        node=node,
+        preformatted=True,
+        config=config,
+        branch=branch
+    )
+    version.preformatted = False
+
+    return version


### PR DESCRIPTION
Adds `setuptools_scm` hooks for rendering valid semver version strings, a
parse function for git tags that returns `semver.VersionInfo` rather than
`packaging.version.Version`, and a convenience `get_version` wrapper
configured with those changes.